### PR TITLE
Don't swallow exceptions inside of tests that use fibers

### DIFF
--- a/lib/em-spec/rspec.rb
+++ b/lib/em-spec/rspec.rb
@@ -21,9 +21,10 @@ module EventMachine
     end
     
     def em(time_to_run = @@_em_default_time_to_finish, &block)
+      em_spec_exception = nil
+
       EM.run do
         timeout(time_to_run) if time_to_run
-        em_spec_exception = nil
         @_em_spec_fiber = Fiber.new do
           begin
             block.call
@@ -34,9 +35,9 @@ module EventMachine
         end  
 
         @_em_spec_fiber.resume
-
-        raise em_spec_exception if em_spec_exception
       end
+
+      raise em_spec_exception if em_spec_exception
     end
 
     def done


### PR DESCRIPTION
If an rspec test is exercising code that uses fibers, any exceptions that occur after a Fiber.yield is called will be swallowed as the code will have dropped to the end of the EM.run block. Consider a simple test case:

``` ruby

gem 'em-spec'
require 'em-spec/rspec'

describe 'test' do
  include EM::SpecHelper

  it 'should raise an exception' do
    em do
      f = Fiber.current
      EM::Timer.new(1) { f.resume }
      Fiber.yield
      raise 'monkey'
      done
    end
  end
end
```

This test will pass without the patch.
