### PR TITLE
Avoid "@_em_timer not initialized" warning

### DIFF
--- a/lib/em-spec/test.rb
+++ b/lib/em-spec/test.rb
@@ -33,7 +33,7 @@ module EventMachine
     end
 
     def timeout(time_to_run)
-      EM.cancel_timer(@_em_timer) if @_em_timer
+      EM.cancel_timer(@_em_timer) if defined? @_em_timer
       @_em_timer = EM.add_timer(time_to_run) { done('timeout exceeded') }
     end
 


### PR DESCRIPTION
(when running ruby with -w)