### PR TITLE
Added MIT license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.2.7
+
+Added MIT license, on popular request.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    em-spec (0.2.6)
+    em-spec (0.2.7)
       eventmachine
 
 GEM
@@ -9,7 +9,7 @@ GEM
   specs:
     bacon (1.1.0)
     diff-lcs (1.1.3)
-    eventmachine (0.12.10)
+    eventmachine (1.0.9.1)
     growl (1.0.3)
     guard (0.8.8)
       thor (~> 0.14.6)
@@ -42,3 +42,6 @@ DEPENDENCIES
   rake (= 0.8.7)
   rspec (> 2.6.0)
   test-unit
+
+BUNDLED WITH
+   1.10.6

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+Copyright (c) 2016 @joshbuddy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-Simple BDD API for testing asynchronous Ruby/EventMachine code
-(c) 2008 Aman Gupta (tmm1)
+# Simple BDD API for testing asynchronous Ruby/EventMachine code
 
-em-spec can be used with either bacon, test unit or rspec.
+`em-spec` can be used with either bacon, test unit or rspec.
 
-=Rspec
-There are two ways to use the Rspec extension.  To use it as a helper, include EM::SpecHelper in your describe block.  You then use the em method to wrap your evented test code.  Inside the em block, you must call #done after your expectations.  Everything works normally otherwise.
+## Rspec
+There are two ways to use with the Rspec gem.
 
+To use it as a helper, include `EM::SpecHelper` in your describe block.
+You then use the `em` method to wrap your evented test code.
+
+Inside the `em` block, you must call `done` after your expectations.
+Everything works normally otherwise.
+
+```ruby
   require "em-spec/rspec"
   describe EventMachine do
     include EM::SpecHelper
@@ -25,7 +31,13 @@ There are two ways to use the Rspec extension.  To use it as a helper, include E
       end
     end
   end
-The other option is to include EM::Spec in your describe block.  This will patch Rspec so that all of your examples run inside an em block automatically:
+```
+
+The other option is to include `EM::Spec` in your describe block.
+
+This will patch Rspec so that all of your examples run inside an `em` block automatically:
+
+```ruby
   require "em-spec/rspec"
   describe EventMachine do
     include EM::Spec
@@ -44,10 +56,14 @@ The other option is to include EM::Spec in your describe block.  This will patch
       }
     end
   end
+```
 
-=Bacon
-The API is identical to Bacon, except that you must explicitly call 'done' after all the current behavior's assertions have been made:
+## Bacon
 
+The API is identical to Bacon, except that you must explicitly call `done`
+after all the current behavior's assertions have been made:
+
+```ruby
   require 'em-spec/bacon'
 
   EM.describe EventMachine do
@@ -75,14 +91,23 @@ The API is identical to Bacon, except that you must explicitly call 'done' after
     end
 
   end
+```
 
-=Test::Unit
-There are two ways to use the Test::Unit extension.  To use it as a helper, include EM::TestHelper in your test unit class.  You then use the em method to wrap your evented test code.  Inside the em block, you must call #done after your expectations.  Everything works normally otherwise.
+## `Test::Unit`
 
+There are two ways to use the `Test::Unit` extension.
+
+To use it as a helper, include `EM::TestHelper` in your test unit class.
+
+You then use the em method to wrap your evented test code.
+
+Inside the em block, you must call `done` after your expectations.
+Everything works normally otherwise.
+
+```ruby
   require 'em-spec/test'
 
   class EmSpecHelperTest < Test::Unit::TestCase
-    
     include EventMachine::TestHelper
   
     def test_trivial
@@ -92,9 +117,14 @@ There are two ways to use the Test::Unit extension.  To use it as a helper, incl
       end
     end
   end
-  
-The other option is to include EM::Test in your test class.  This will patch Test::Unit so that all of your examples run inside an em block automatically:
+```
 
+The other option is to include `EM::Test` in your test class.
+
+This will patch `Test::Unit` so that all of your examples run inside an
+`em` block automatically:
+
+```ruby
   require 'em-spec/test'
 
   class EmSpecTest < Test::Unit::TestCase
@@ -110,9 +140,8 @@ The other option is to include EM::Test in your test class.  This will patch Tes
       }
     end
   end
+```
 
-Resources:
+## Resources
 
-* Git repository: http://github.com/tmm1/em-spec
-* Bacon: http://groups.google.com/group/comp.lang.ruby/browse_thread/thread/30b07b651b0662fd
-* Initial announcement: http://groups.google.com/group/eventmachine/browse_thread/thread/8b4e7ead72f9d013
+* [Bacon](http://groups.google.com/group/comp.lang.ruby/browse_thread/thread/30b07b651b0662fd)

--- a/em-spec.gemspec
+++ b/em-spec.gemspec
@@ -10,10 +10,8 @@ Gem::Specification.new do |s|
   s.summary = "BDD for Ruby/EventMachine"
   s.description = "Simple BDD API for testing asynchronous Ruby/EventMachine code"
   s.email = %q{schmurfy@gmail.com}
-  s.extra_rdoc_files = ['README.rdoc']
   s.files = `git ls-files`.split("\n")
   s.homepage = %q{https://github.com/joshbuddy/em-spec}
-  s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
   s.test_files = `git ls-files`.split("\n").select{|f| f =~ /^test/}

--- a/lib/em-spec/version.rb
+++ b/lib/em-spec/version.rb
@@ -1,5 +1,5 @@
 module EventMachine
   module Spec
-    VERSION = '0.2.6'
+    VERSION = '0.2.7'
   end
 end


### PR DESCRIPTION
* Added MIT license, as requested in issue #12.
* Converted README to MarkDown for better code preview.
* Bumped gem version and pushed to http://rubygems.org.