### PR TITLE
Properly wrap examples in `em do` for EM::Spec

### DIFF
--- a/lib/em-spec/rspec.rb
+++ b/lib/em-spec/rspec.rb
@@ -54,19 +54,24 @@ module EventMachine
     end
     
   end
-  
-  module Spec
 
+  module Spec
+    
     include SpecHelper
 
-    def instance_eval(&block)
-      em do
-        super(&block)
-      end
+    def self.append_features(mod)
+      mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        around(:all) do |example|
+          em do
+            example.run
+          end
+        end
+      RUBY
     end
 
   end
-  
+
+
 end
 
 

--- a/lib/em-spec/rspec.rb
+++ b/lib/em-spec/rspec.rb
@@ -52,15 +52,14 @@ module EventMachine
       EM.stop_event_loop if EM.reactor_running?
       @_em_spec_fiber.resume if @_em_spec_fiber.alive?
     end
-    
+
   end
 
   module Spec
-    
-    include SpecHelper
 
     def self.append_features(mod)
       mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        include SpecHelper
         around(:all) do |example|
           em do
             example.run
@@ -73,5 +72,3 @@ module EventMachine
 
 
 end
-
-


### PR DESCRIPTION
Perhaps someone could shed some light on how the `instance_eval(&block)` was supposed to be working, but it seemed to have no effect when including that module in my SpecHelper.

This change effectively ensures all examples are run within the em block